### PR TITLE
1.0.0 - breaking changes. Plot, print and to_dataframe now also accepts databases as inputs if a function is supplied.

### DIFF
--- a/dreamtools/__init__.py
+++ b/dreamtools/__init__.py
@@ -1,6 +1,6 @@
 from .gams_pandas import *
 
-__version__ = "0.7.0"
+__version__ = "1.0.0"
 
 # Global setting controlling the default position of the time index (-1 = last index is time)
 X_AXIS_INDEX = -1

--- a/dreamtools/gams_pandas/gams_pandas.py
+++ b/dreamtools/gams_pandas/gams_pandas.py
@@ -22,7 +22,7 @@ class GamsPandasDatabase:
   Changes to retrieved series are written to the GAMS database on export.
   """
 
-  def __init__(self, database=None, workspace=None, auto_sort_index=True, sparse=True):
+  def __init__(self, database=None, workspace=None, auto_sort_index=True, sparse=True, reference_database=None):
     if database is None:
       if workspace is None:
         workspace = gams.GamsWorkspace()
@@ -31,6 +31,7 @@ class GamsPandasDatabase:
     self.gams2numpy = gams2numpy.Gams2Numpy(database.workspace.system_directory)
     self.auto_sort_index = auto_sort_index
     self.sparse = sparse
+    self.reference_database = reference_database
     self.series = {}
 
   def __getattr__(self, item):

--- a/dreamtools/multiindex_plotly/test_timeseries_analysis.py
+++ b/dreamtools/multiindex_plotly/test_timeseries_analysis.py
@@ -1,16 +1,16 @@
 import os
-
 import sys
 sys.path.insert(0, os.getcwd())
+os.chdir("../..")
 
+import pytest
 import numpy as np
 import pandas as pd
 import dreamtools as dt
 
-dt.REFERENCE_DATABASE = r = dt.Gdx("test.gdx")
-s = dt.Gdx("test.gdx")
-
-def test_to_dataframe():
+def test_to_dataframe_with_series():
+  dt.REFERENCE_DATABASE = dt.Gdx("test.gdx")
+  s = dt.Gdx("test.gdx")
   dt.time(2025, 2040)
   assert dt.to_dataframe(s.qBNP).shape == (16, 1)
   assert dt.to_dataframe(s.qY).shape == (16, 1)
@@ -19,4 +19,36 @@ def test_to_dataframe():
   s.foo = s.qY.loc[s.sp]
   s.foo.name = "foo"
   assert dt.to_dataframe(s.foo).shape == (16, 8)
-  dt.to_dataframe(s.foo, "q")
+  with pytest.raises(KeyError):
+    dt.to_dataframe(s.foo, "q")
+
+def test_to_dataframe_with_database():
+  dt.REFERENCE_DATABASE = dt.Gdx("test.gdx")
+  s = dt.Gdx("test.gdx")
+  dt.time(2025, 2040)
+  assert dt.to_dataframe(s, function = lambda s: s.qBNP).shape == (16, 1)
+  assert dt.to_dataframe(s, function = lambda s: s.qY).shape == (16, 1)
+  assert dt.to_dataframe(s, function = lambda s: s.qY[s.s]).shape == (16, 9)
+  assert dt.to_dataframe(s, "q", lambda s: s.qY[s.s]).shape == (16, 9)
+  assert dt.to_dataframe(s, "q", lambda s: s.pY[s.s] * s.qY[s.s]).shape == (16, 9)
+  
+def test_to_dataframe_with_multiple_baselines():
+  b1 = dt.Gdx("test.gdx")
+  b2 = dt.Gdx("test.gdx")
+  s1 = dt.Gdx("test.gdx")
+  s2 = dt.Gdx("test.gdx")
+  s1.reference_database = b1
+  s2.reference_database = b2
+  b1.qY *= 2
+  b2.qY /= 2
+  dt.time(2025, 2040)
+  assert dt.to_dataframe([s1, s2], "q", lambda s: s.pY[s.s] * s.qY[s.s]).shape == (16, 9*2)
+  q = dt.to_dataframe([s1, s2], "q", lambda s: s.pY['tje'] * s.qY['tje'], ["s1", "s2"])
+  assert all(q["s1"] == -0.5)
+  assert all(q["s2"] == 1)
+
+  s1 = dt.Gdx("test.gdx")
+  s2 = dt.Gdx("test.gdx")
+  q = dt.to_dataframe([s1, s2], "q", lambda s: s.pY['tje'] * s.qY['tje'], ["s1", "s2"], baselines=[b1, b2])
+  assert all(q["s1"] == -0.5)
+  assert all(q["s2"] == 1)


### PR DESCRIPTION
Breaking changes. Plot, print and to_dataframe now also accepts databases as inputs if a function is supplied (function receives database as input).

Default aggregation is no longer based on reference database, but instead always aggregates as much as possible. reference_database property added to GamsPandasDatabase, used to specify a baseline database to be used with another database.