### PR TITLE
GamsPandasDatabase: Correct Exception when accessing non-existent att…

### DIFF
--- a/dreamtools/gams_pandas/gams_pandas.py
+++ b/dreamtools/gams_pandas/gams_pandas.py
@@ -35,7 +35,10 @@ class GamsPandasDatabase:
     self.series = {}
 
   def __getattr__(self, item):
-    return self[item]
+    try:
+      return self[item]
+    except KeyError as err:
+      raise AttributeError(*err.args) from err
 
   def copy(self):
     obj = type(self).__new__(self.__class__)


### PR DESCRIPTION
…ribute.

__getattr__ method in GamsPandasDatabase threw KeyError when accessing non-existent attribute. This meant that using getattr(obj, attr, default) would raise KeyError instead of returning default value. This is now fixed with __getattr__ raising AttributeError if KeyError is thown.

See attached screenshot for error when using getattr on GamsPandasDatabase obj.

I ran into this issue when trying to make a deepcopy of a GamsPandasDatabase object because deepcopy was searching for a __deepcopy__ method but failed to return the appropriate default value because a KeyError was thrown instead of an AttributeError.

![image](https://github.com/MartinBonde/dream-tools/assets/161837811/a2fbfe3a-e732-4905-b96e-efa2120a2638)
