### PR TITLE
Substituting full gams-api for gams.transfer in gams_pandas module

### DIFF
--- a/dreamtools/gams_pandas/__init__.py
+++ b/dreamtools/gams_pandas/__init__.py
@@ -1,4 +1,3 @@
-import numpy as np
 from .gams_pandas import GamsPandasDatabase
 from .gdx import Gdx
 from .utility import *

--- a/dreamtools/gams_pandas/__init__.py
+++ b/dreamtools/gams_pandas/__init__.py
@@ -1,3 +1,4 @@
+import numpy as np
 from .gams_pandas import GamsPandasDatabase
 from .gdx import Gdx
 from .utility import *

--- a/dreamtools/gams_pandas/gdx.py
+++ b/dreamtools/gams_pandas/gdx.py
@@ -1,6 +1,5 @@
 import os
 
-import gams
 import gams.transfer as gt
 
 from .gams_pandas import GamsPandasDatabase, logger

--- a/dreamtools/gams_pandas/gdx.py
+++ b/dreamtools/gams_pandas/gdx.py
@@ -1,6 +1,7 @@
 import os
 
 import gams
+import gams.transfer as gt
 
 from .gams_pandas import GamsPandasDatabase, logger
 
@@ -14,11 +15,9 @@ class Gdx(GamsPandasDatabase):
     if not os.path.splitext(file_path)[1]:
       file_path = file_path + ".gdx"
     self.abs_path = os.path.abspath(file_path)
-    logger.info(f"Open GDX file from {self.abs_path}.")
-    if workspace is None:
-      workspace = gams.GamsWorkspace()
-    database = workspace.add_database_from_gdx(self.abs_path)
-    super().__init__(database, sparse=sparse)
+    container=gt.Container()
+    container.read(self.abs_path)
+    super().__init__(container, sparse=sparse)
 
   def export(self, path=None, relative_path=True):
     """

--- a/dreamtools/gams_pandas/utility.py
+++ b/dreamtools/gams_pandas/utility.py
@@ -14,18 +14,16 @@ def all_na(x):
 def domains_as_strings(symbol):
     if hasattr(symbol, "domain"):
         return [getattr(d, "name", d) for d in symbol.domain]
-        #return symbol.domain
     elif hasattr(symbol, "domains"):
         return symbol.domains
     else:
         raise AttributeError(f"Symbol {symbol.name} has neither 'domain' nor 'domains' attribute")
     
 def index_names_from_symbol(symbol):
-  """
-  Return the domain names of a GAMS symbol,
+  ''' Returns the domain names of a GAMS symbol,
   except ['*'] cases are replaced by the name of the symbol
   and ['*',..,'*'] cases are replaced with ['index_0',..'index_n']
-  """
+  '''
   index_names = list(domains_as_strings(symbol))
   if index_names == ["*"]:
     return [symbol.name]
@@ -35,20 +33,19 @@ def index_names_from_symbol(symbol):
         index_names[i] = f"index_{i}"
   return index_names
 
-
 def better_index_from_symbol(symbol):
   """Return a Pandas Index based on the records and domain names of a GAMS symbol."""
   records=symbol.records
   if len(domains_as_strings(symbol)) > 1:
     keys=[tuple(row) for row in records.iloc[:,len(symbol.domains)].values]
-    index = list(map_to_index_where_possible(pd.MultiIndex.from_tuples(keys, names=index_names_from_symbol(symbol))))
+    index = list(map_to_int_where_possible(pd.MultiIndex.from_tuples(keys, names=index_names_from_symbol(symbol))))
     index.name = symbol.name
   elif len(domains_as_strings(symbol)) == 1:
     keys=records.iloc[:,0].tolist()
     index = pd.Index(map_to_int_where_possible(pd.Index(keys, name=index_names_from_symbol(symbol)[0])))
     index.name=domains_as_strings(symbol)[0]
   else:
-    return None  
+    return None
   if isinstance(symbol, gt.Set):
     index.domains = domains_as_strings(symbol)
     idx = pd.MultiIndex.from_frame(symbol.records[symbol.domain_labels])
@@ -61,8 +58,7 @@ def better_index_from_symbol(symbol):
         index.texts = pd.Series(symbol.records['element_text'].values, index=idx, name=symbol.name)
     else:
         index.texts = pd.Series([None] * len(symbol.records), index=idx, name=symbol.name)
-  
-  return index  
+  return index 
 
 
 def symbol_is_scalar(symbol):
@@ -96,32 +92,6 @@ def map_to_int_where_possible(iter):
   """Returns an iterable where each element is converted to an integer if possible for that element."""
   return map_lowest_level(try_to_int, iter)
 
-
-def merge_symbol_records(series, symbol):
-  """Convert Pandas series to records in a GAMS Symbol"""
-  if isinstance(symbol, gams.GamsSet):
-    attr = "text"
-  elif isinstance(symbol, gams.GamsVariable):
-    attr = "level"
-  elif isinstance(symbol, gams.GamsParameter):
-    attr = "value"
-  for k, v in series.items():
-    setattr(symbol.merge_record(k), attr, v)
-
-
-def fill_missing_combinations(series, sets_database=None, fill_value=pd.NA):
-  """
-  Return copy of series with all combinations filled with fill_value.
-  If a database is supplied we look up the sets in the database, otherwise we only fill set elements already in use.
-  """
-  sets = [i.unique() for i in series.index.levels[:]]
-  if sets_database is not None:
-    for i, set_name in enumerate(series.index.names):
-      if set_name in sets_database:
-        sets[i] = sets_database[set_name]
-  all_combinations = pd.MultiIndex.from_product(sets)
-  return series.reindex(all_combinations, fill_value=fill_value)
-
 def safe_set_records(symbol, value):
     '''This function ensures domains are strings + categorigcal and values are simple (floats) and categorical, required for export with gams.transfer'''
     if symbol_is_scalar(symbol):
@@ -130,6 +100,8 @@ def safe_set_records(symbol, value):
 
     if isinstance(value, pd.Series):
         value = value.reset_index()
+        if symbol.name in value.columns and 'level' not in value.columns:
+           value.rename(columns={symbol.name:'level'},inplace=True)
     elif isinstance(value, (list, tuple)) and isinstance(value[0], dict):
         value = pd.DataFrame(value)
     elif not isinstance(value, pd.DataFrame):
@@ -148,4 +120,5 @@ def safe_set_records(symbol, value):
     data_columns=set(value.columns)-{d.name if hasattr(d,'name') else d for d in symbol.domain}
     for col in data_columns:
        value[col]=value[col].astype(float)
+
     symbol.records = value

--- a/dreamtools/gams_pandas/utility.py
+++ b/dreamtools/gams_pandas/utility.py
@@ -33,7 +33,7 @@ def index_names_from_symbol(symbol):
         index_names[i] = f"index_{i}"
   return index_names
 
-def better_index_from_symbol(symbol):
+def index_from_symbol(symbol):
   """Return a Pandas Index based on the records and domain names of a GAMS symbol."""
   records=symbol.records
   if len(domains_as_strings(symbol)) > 1:


### PR DESCRIPTION
Some testing is still to be done. gams.database is fully replaced with gams.transfer.container causing some methods to be deprecated. Whenever possible we adhere to the principle of making existing dream-tools syntax compatible.